### PR TITLE
fixes letsencrypt autorenew PythonDialogBug issue (#55)

### DIFF
--- a/15-https
+++ b/15-https
@@ -44,7 +44,7 @@ if [ "$SSL_TYPE" == "letsencrypt" ]; then
 
   if [ ! -f /is-baking ]; then
     # Perform the Let's Encrypt certificate issuance
-    /srv/letsencrypt/letsencrypt-auto certonly --keep --debug --agree-tos --webroot -w /srv/letsencrypt-webroot --email $SSL_EMAIL -d $PHABRICATOR_HOST
+    /srv/letsencrypt/letsencrypt-auto certonly --text --non-interactive --keep --debug --agree-tos --webroot -w /srv/letsencrypt-webroot --email $SSL_EMAIL -d $PHABRICATOR_HOST
   fi
 
   if [ ! -f /baked ]; then
@@ -52,7 +52,7 @@ if [ "$SSL_TYPE" == "letsencrypt" ]; then
     cat >/etc/cron.weekly/letsencrypt <<EOF
 #!bin/bash
 
-/srv/letsencrypt/letsencrypt-auto certonly --keep --debug --agree-tos --webroot -w /srv/letsencrypt-webroot --email $SSL_EMAIL -d $PHABRICATOR_HOST
+/srv/letsencrypt/letsencrypt-auto certonly --text --non-interactive --keep --debug --agree-tos --webroot -w /srv/letsencrypt-webroot --email $SSL_EMAIL -d $PHABRICATOR_HOST
 EOF
     chmod a+x /etc/cron.weekly/letsencrypt
 


### PR DESCRIPTION
* fixes letsencrypt autorenew PythonDialogBug issue

As of https://github.com/certbot/certbot/issues/1154#issuecomment-151616937

* letsencrypt add --non-interactive as docs state

as in https://github.com/certbot/certbot/issues/1154#issuecomment-211229645

also, dialog should be removed soon, so this problem should disappear https://github.com/certbot/certbot/issues/1154#issuecomment-256732994